### PR TITLE
prevent ECONNRESET from breaking sslinfo

### DIFF
--- a/lib/cipher.js
+++ b/lib/cipher.js
@@ -87,16 +87,20 @@ function trySSLCipher(options) {
             deferred.resolve({protocol: options.secureProtocol, protocolCommonName: options.protocolCommonName, cipher: options.ciphers, enabled: false});
         } else if (errorString.indexOf('no ciphers available') !== -1) {
             deferred.resolve({protocol: options.secureProtocol, protocolCommonName: options.protocolCommonName, cipher: options.ciphers, enabled: false, unsupported: true});
+        } else if (error.code=='ECONNRESET') {
+            deferred.resolve({ protocol: options.secureProtocol, protocolCommonName: options.protocolCommonName, cipher: options.ciphers, enabled: false});
         } else {
-            console.log(errorString);
             deferred.reject({
                 host: options.host,
                 port: options.port,
                 protocol: options.secureProtocol,
                 protocolCommonName: options.protocolCommonName,
                 cipher: options.ciphers,
-                error: error
-            });
+                error: error});
+            // deferred.reject(error);
+            // it would be best to reject with an error object because it's more standard
+            // however, so many errors can occur in TLS it's hard to say if they mean a problem or an unsupported cipher
+            // https://github.com/nodejs/node/blob/bdd37e1fac77b75c56eb3a7f566ae374ac668a64/deps/openssl/openssl/ssl/ssl_err.c#L379
         }
         socket.end();
     });


### PR DESCRIPTION
Hi ! Here's a bug fix... in case of ECONNRESET on node0.12.9, sslinfo could fail when checking ciphers... ECONNRESET would cause a promise rejection, which would then break the Promise.all just because the server closed the socket.

example to reproduce the problem:

```
var sslinfo=require('sslinfo');
var promise = sslinfo.getServerResults({host: 'MDM.VILLAGECARE.ORG',port:443, servername: 'MDM.VILLAGECARE.ORG'});
/// loads of ECONNREST in the console
promise.then(console.log);
```

With the fix, it will work perfectly (and I've removed the `console.log`).

Hope you can merge easily
